### PR TITLE
Fix distro+version for Ubuntu LTS

### DIFF
--- a/perl/sysinfo.pl
+++ b/perl/sysinfo.pl
@@ -389,8 +389,8 @@ if($linux) {
 					$realdistro	=~ s/"$//;
 					$distro		= $realdistro;
 					$distrov	= $realdistro;
-					$distro		=~ s/ [0-9.]*$//;
-					$distrov	=~ s/.* ([0-9.]*)/$1/;
+					$distro		=~ s/ [0-9.]+.*$//;
+					$distrov	=~ s/.* ([0-9.]+.*)/$1/;
 				}
 			}
 		}


### PR DESCRIPTION
Before:

<pre>
# 'Distro: Ubuntu 10.04.3 LTS LTS'
$distro == 'Ubuntu 10.04.3 LTS';
$distrov == 'LTS';
</pre>


After:

<pre>
# 'Distro: Ubuntu 10.04.3 LTS'
$distro == 'Ubuntu';
$distrov == '10.04.3 LTS';
</pre>


Can't see this conflicting with non-LTS Ubuntu versions but I don't know what formats other Debian-based distros use.
