### PR TITLE
Update sysinfo.pl

### DIFF
--- a/perl/sysinfo.pl
+++ b/perl/sysinfo.pl
@@ -40,6 +40,8 @@
 # ported to WeeChat (http://www.weechat.org/) by Nils Görs. Copyright
 # (c) 2011-2013 Nils Görs
 #
+# 2015-01-10: 0.8 riotpunch (theriotpunch@gmail.com)
+#	    : fixed osx/darwin uptime being treated incorrectly
 # 2013-08-10: 0.7 nils_2 (freenode@nils_2)
 #           : add: support of vcgencmd (eg raspberry pi)
 # 2013-03-06: 0.6 Thomas Poechtrager <t.poechtrager@gmail.com>
@@ -66,7 +68,7 @@ use POSIX qw(floor);
 use strict;
 
 my $SCRIPT_NAME         = "sysinfo";
-my $SCRIPT_VERSION      = "0.7";
+my $SCRIPT_VERSION      = "0.8";
 my $SCRIPT_DESCR        = "provides a system info command";
 my $SCRIPT_LICENSE      = "GPL3";
 my $SCRIPT_AUTHOR       = "Nils Görs <weechatter\@arcor.de>";

--- a/perl/sysinfo.pl
+++ b/perl/sysinfo.pl
@@ -925,10 +925,10 @@ sub uptime {
 		}
 		return $var;
 	} else {
-		if($freebsd || $dragonfly) {
+		if($freebsd || $dragonfly || $darwin) {
 			$var = `$sysctl -n kern.boottime | awk '{print \$4}'`;
 		}
-		if($netbsd || $openbsd || $darwin) {
+		if($netbsd || $openbsd) {
 			$var = `$sysctl -n kern.boottime`;
 		}
 		if($linux) {


### PR DESCRIPTION
Fixed uptime for Darwin/OSX Yosemite.

The uptime output from `/sysinfo` and `/sysinfo uptime` looked as follows

> | 17:15:31                  | Uptime: 16444d 6h 15m

With the following error in weechat buffer

> warning: Argument "{ sec = 1420582571 usec = 0 } Wed Jan  7 09:16:11 2015" isn't numeric in subtraction (-) at /Users/riot/.weechat/perl/autoload/sysinfo.pl line941.
