### PR TITLE
quick_force_color.py: Misc. fixes and usability improvements

### DIFF
--- a/python/quick_force_color.py
+++ b/python/quick_force_color.py
@@ -92,10 +92,7 @@ def nick_colors_cmd_cb(data, buffer, args):
         return weechat.WEECHAT_RC_OK
 
     if (argv[0].lower() == 'add') and (len(argv) == 3):
-        if argv[1] in colored_nicks:                                                            # search if nick exists
-            colored_nicks[argv[1]] = argv[2]
-        else:
-            colored_nicks[argv[1]] = argv[2]                                                    # add [nick] = [color]
+        colored_nicks[argv[1]] = argv[2]
         save_new_force_nicks()
 
     if (argv[0].lower() == 'del') and (len(argv) == 2):

--- a/python/quick_force_color.py
+++ b/python/quick_force_color.py
@@ -94,6 +94,12 @@ def nick_colors_cmd_cb(data, buffer, args):
                 weechat.prnt(buffer,"%s%s: %s" % (weechat.color(color),nick,color))
 
     elif (argv[0].lower() == 'add') and (len(argv) == 3):
+        if argv[1] in colored_nicks:
+            weechat.prnt(buffer, "Changing nick '%s' to color %s%s" % (
+                argv[1], weechat.color(argv[2]), argv[2]))
+        else:
+            weechat.prnt(buffer, "Adding nick '%s' with color %s%s" % (
+                argv[1], weechat.color(argv[2]), argv[2]))
         colored_nicks[argv[1]] = argv[2]
         save_new_force_nicks()
 
@@ -101,6 +107,9 @@ def nick_colors_cmd_cb(data, buffer, args):
         if argv[1] in colored_nicks:                                                            # search if nick exists
             del colored_nicks[argv[1]]
             save_new_force_nicks()
+            weechat.prnt(buffer, "Removed nick '%s'" % argv[1])
+        else:
+            weechat.prnt(buffer, "Nick '%s' not found in nick_color_force" % argv[1])
 
     else:
         print_usage(buffer)

--- a/python/quick_force_color.py
+++ b/python/quick_force_color.py
@@ -148,10 +148,10 @@ if __name__ == "__main__":
         version = weechat.info_get('version_number', '') or 0
         if int(version) >= 0x00030400:
             weechat.hook_command(SCRIPT_NAME,SCRIPT_DESC,
-            'add <nick> <color> || del <nick< <color> || list',
+            'add <nick> <color> || del <nick> <color> || list [<nick>]',
             'add <nick> <color>: add a nick with its color to irc.look.nick_color_force\n'
             'del <nick>        : delete given nick with its color from irc.look.nick_color_force\n'
-            'list <nick>       : list all forced nicks with its assigned color or optional from one nick\n\n'
+            'list [<nick>]     : list all forced nicks with its assigned color or optional from one nick\n\n'
             'Examples:\n'
             ' add nick nils_2 with color red:\n'
             '  /' + SCRIPT_NAME + ' add nils_2 red\n'

--- a/python/quick_force_color.py
+++ b/python/quick_force_color.py
@@ -59,14 +59,19 @@ DEFAULT_COLORS = {  0 : "darkgray", 1 : "red", 2 : "lightred", 3 : "green",
 
 colored_nicks = {}
 # ================================[ callback ]===============================
+def print_usage(buffer):
+    weechat.prnt(buffer, "Usage: /%s list [nick] | add nick color | del nick" % SCRIPT_NAME)
+
 def nick_colors_cmd_cb(data, buffer, args):
     global colored_nicks
 
     if args == "":                                                                              # no args given. quit
+        print_usage(buffer)
         return weechat.WEECHAT_RC_OK
 
     argv = args.strip().split(" ")
     if (len(argv) == 0) or (len(argv) >= 4):                                                    # maximum of 3 args!!
+        print_usage(buffer)
         return weechat.WEECHAT_RC_OK
 
     bufpointer = weechat.window_get_pointer(buffer,'buffer')                                    # current buffer
@@ -76,29 +81,29 @@ def nick_colors_cmd_cb(data, buffer, args):
     if argv[0].lower() == 'list':                                                               # list all nicks
         if len(colored_nicks) == 0:
             weechat.prnt(buffer,'%sno nicks in \"irc.look.nick_color_force\"...' % weechat.prefix("error"))
-            return weechat.WEECHAT_RC_OK
-        if len(argv) == 2:
+        elif len(argv) == 2:
             if argv[1] in colored_nicks:
                 color = colored_nicks[argv[1]]                                                  # get color from given nick
                 weechat.prnt(buffer,"%s%s: %s" % (weechat.color(color),argv[1],color))
             else:
                 weechat.prnt(buffer,"no color set for: %s" % (argv[1]))
-            return weechat.WEECHAT_RC_OK
+        else:
+            weechat.prnt(buffer,"List of nicks in : nick_color_force")
+#            for nick,color in colored_nicks.items():
+            for nick,color in list(colored_nicks.items()):
+                weechat.prnt(buffer,"%s%s: %s" % (weechat.color(color),nick,color))
 
-        weechat.prnt(buffer,"List of nicks in : nick_color_force")
-#        for nick,color in colored_nicks.items():
-        for nick,color in list(colored_nicks.items()):
-            weechat.prnt(buffer,"%s%s: %s" % (weechat.color(color),nick,color))
-        return weechat.WEECHAT_RC_OK
-
-    if (argv[0].lower() == 'add') and (len(argv) == 3):
+    elif (argv[0].lower() == 'add') and (len(argv) == 3):
         colored_nicks[argv[1]] = argv[2]
         save_new_force_nicks()
 
-    if (argv[0].lower() == 'del') and (len(argv) == 2):
+    elif (argv[0].lower() == 'del') and (len(argv) == 2):
         if argv[1] in colored_nicks:                                                            # search if nick exists
             del colored_nicks[argv[1]]
             save_new_force_nicks()
+
+    else:
+        print_usage(buffer)
 
     return weechat.WEECHAT_RC_OK
 

--- a/python/quick_force_color.py
+++ b/python/quick_force_color.py
@@ -139,6 +139,7 @@ def force_nick_colors_completion_cb(data, completion_item, buffer, completion):
 def create_list():
     global nick_color_force,colored_nicks
 #        colored_nicks = dict([elem.split(':') for elem in nick_color_force.split(';')])
+    colored_nicks = {}
     nick_color_force = weechat.config_string(weechat.config_get('irc.look.nick_color_force'))   # get list
     if nick_color_force != '':
         nick_color_force = nick_color_force.strip(';')                                          # remove ';' at beginning and end of string

--- a/python/quick_force_color.py
+++ b/python/quick_force_color.py
@@ -105,7 +105,7 @@ def nick_colors_cmd_cb(data, buffer, args):
 def save_new_force_nicks():
     global colored_nicks
 #    new_nick_color_force = ';'.join([ ':'.join(item) for item in colored_nicks.items()])
-    new_nick_color_force = ';'.join([ ':'.join(item) for item in list(colored_nicks.items())])
+    new_nick_color_force = ';'.join([ ':'.join(item) for item in sorted(colored_nicks.items())])
     config_pnt = weechat.config_get('irc.look.nick_color_force')
     weechat.config_option_set(config_pnt,new_nick_color_force,1)
 


### PR DESCRIPTION
Fixes for some issues that were bugging me. :-)
- Provide feedback for operations and bad command syntax. I kept having the script do nothing at all and never knew it because I got the syntax wrong and it never told me. Adding/changing nick colors now shows the nick and its color so I can verify I entered them correctly. Both ‘add’ and ‘del’ commands indicate what was done and whether the nick was already in nick_color_force.
- Nicks are written to nick_color_force in sorted order so it's easier to manually edit later. (Otherwise, just writing them directly results in a “shuffled” order derived by Python's internal dict structure in memory.)
- Fix a bug where manually-removed nicks in nick_color_force are still recognized and written back due to the internal dict not being cleared before being reloaded from nick_color_force.
- Clarify help syntax (‘nick’ specification in list command is optional).
